### PR TITLE
Add typo ignore list feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,28 @@ Fast Travel uses a command-based syntax defined in the `config.json` file. Comma
     - Typing `$AAPL` opens the Yahoo Finance quote page for AAPL.
 
 - **Subcommands / Custom Patterns**
-  - **Syntax:** `<command> <subcommand>/<query>` or using a custom regex defined in the config.  
-  - **Examples:**  
+  - **Syntax:** `<command> <subcommand>/<query>` or using a custom regex defined in the config.
+  - **Examples:**
     - Typing `yt subs` opens your YouTube subscriptions.
     - Typing `gh u/DoubleGremlin181` searches for DoubleGremlin181's profile on GitHub.
+
+### Typo Detection & Ignore List
+
+Fast Travel includes smart typo detection that suggests corrections when you mistype a command. If you encounter a false positive (a legitimate word or custom shortcut flagged as a typo), you can permanently ignore it:
+
+- **Ignoring a Typo:**
+  - When the typo suggestion appears, press **`i`** or click **"Permanently ignore typo"**
+  - The word will be added to your device's ignore list and won't trigger suggestions in the future
+  - After ignoring, Fast Travel will proceed with a Google search using your original query
+
+- **Managing the Ignore List:**
+  - The ignore list is stored locally in your browser's localStorage
+  - To view or edit ignored words:
+    1. Open your browser's Developer Tools (press **F12**)
+    2. Go to the **Application** (Chrome/Edge) or **Storage** (Firefox) tab
+    3. Navigate to **Local Storage** → your domain
+    4. Find the `typoIgnoreList` key to view, edit, or delete entries
+  - To clear the entire list, simply delete the `typoIgnoreList` key from localStorage
 
 ### OS-Specific Options
 

--- a/README.md
+++ b/README.md
@@ -111,24 +111,6 @@ Fast Travel uses a command-based syntax defined in the `config.json` file. Comma
     - Typing `yt subs` opens your YouTube subscriptions.
     - Typing `gh u/DoubleGremlin181` searches for DoubleGremlin181's profile on GitHub.
 
-### Typo Detection & Ignore List
-
-Fast Travel includes smart typo detection that suggests corrections when you mistype a command. If you encounter a false positive (a legitimate word or custom shortcut flagged as a typo), you can permanently ignore it:
-
-- **Ignoring a Typo:**
-  - When the typo suggestion appears, press **`i`** or click **"Permanently ignore typo"**
-  - The word will be added to your device's ignore list and won't trigger suggestions in the future
-  - After ignoring, Fast Travel will proceed with a Google search using your original query
-
-- **Managing the Ignore List:**
-  - The ignore list is stored locally in your browser's localStorage
-  - To view or edit ignored words:
-    1. Open your browser's Developer Tools (press **F12**)
-    2. Go to the **Application** (Chrome/Edge) or **Storage** (Firefox) tab
-    3. Navigate to **Local Storage** → your domain
-    4. Find the `typoIgnoreList` key to view, edit, or delete entries
-  - To clear the entire list, simply delete the `typoIgnoreList` key from localStorage
-
 ### OS-Specific Options
 
 Fast Travel adjusts its behavior based on your device’s operating system. The `config.json` file includes routes optimized for various platforms:
@@ -152,6 +134,24 @@ For instance, the `apps` command provides different routing options depending on
   The file is parsed sequentially. If a query matches multiple patterns, the first match is used. Arrange your custom patterns accordingly to ensure the desired behavior.
 
 Tip: Adding `debug=true` to the URL parameters prints debug statements to the console and adds a 3s delay.
+
+## Typo Detection & Ignore List
+
+Fast Travel includes smart typo detection that suggests corrections when you mistype a command. If you encounter a false positive (a legitimate word or custom shortcut flagged as a typo), you can permanently ignore it:
+
+- **Ignoring a Typo:**
+  - When the typo suggestion appears, press **`i`** or click **"Permanently ignore typo"**
+  - The word will be added to your device's ignore list and won't trigger suggestions in the future
+  - After ignoring, Fast Travel will proceed with a Google search using your original query
+
+- **Managing the Ignore List:**
+  - The ignore list is stored locally in your browser's localStorage
+  - To view or edit ignored words:
+    1. Open your browser's Developer Tools (press **F12**)
+    2. Go to the **Application** (Chrome/Edge) or **Storage** (Firefox) tab
+    3. Navigate to **Local Storage** → your domain
+    4. Find the `typoIgnoreList` key to view, edit, or delete entries
+  - To clear the entire list, simply delete the `typoIgnoreList` key from localStorage
 
 ## Credits
 

--- a/index.html
+++ b/index.html
@@ -262,6 +262,43 @@
         );
       }
 
+      // Typo ignore list management using localStorage
+      function getIgnoredTypos() {
+        try {
+          const ignored = localStorage.getItem("typoIgnoreList");
+          return ignored ? JSON.parse(ignored) : [];
+        } catch (error) {
+          loggerHelper("Error reading typo ignore list:", error);
+          return [];
+        }
+      }
+
+      function addIgnoredTypo(word) {
+        try {
+          const ignored = getIgnoredTypos();
+          const lowerWord = word.toLowerCase();
+          if (!ignored.includes(lowerWord)) {
+            ignored.push(lowerWord);
+            localStorage.setItem("typoIgnoreList", JSON.stringify(ignored));
+            loggerHelper("Added to typo ignore list:", lowerWord);
+          }
+        } catch (error) {
+          loggerHelper("Error adding to typo ignore list:", error);
+        }
+      }
+
+      function removeIgnoredTypo(word) {
+        try {
+          const ignored = getIgnoredTypos();
+          const lowerWord = word.toLowerCase();
+          const filtered = ignored.filter((w) => w !== lowerWord);
+          localStorage.setItem("typoIgnoreList", JSON.stringify(filtered));
+          loggerHelper("Removed from typo ignore list:", lowerWord);
+        } catch (error) {
+          loggerHelper("Error removing from typo ignore list:", error);
+        }
+      }
+
       function levenshtein(a, b) {
         const matrix = [];
         for (let i = 0; i <= b.length; i++) {
@@ -288,6 +325,14 @@
 
       function findClosestCommand(input) {
         if (!window.config) return null;
+
+        // Check if this word is in the ignore list
+        const ignoredTypos = getIgnoredTypos();
+        if (ignoredTypos.includes(input.toLowerCase())) {
+          loggerHelper("Debug: Command in typo ignore list:", input);
+          return null;
+        }
+
         let closest = null;
         let minDistance = Infinity;
         Object.keys(config.commands).forEach(function (cmd) {
@@ -484,6 +529,9 @@
                   <button id="googleButton" class="error-btn">
                     Search on Google <span class="shortcut-hint">(g)</span>
                   </button>
+                  <button id="ignoreButton" class="error-btn">
+                    Ignore this typo <span class="shortcut-hint">(i)</span>
+                  </button>
                 </div>
               </div>
               ${generateCommandList()}
@@ -513,6 +561,18 @@
                 redirectHelper(redirectUrl);
               });
 
+            document
+              .getElementById("ignoreButton")
+              .addEventListener("click", () => {
+                addIgnoredTypo(command);
+                const googleCmd = config.commands["g"];
+                const url = googleCmd.routes[0].fallbackUrl.replace(
+                  "{args}",
+                  encodeURIComponent(query)
+                );
+                redirectHelper(url);
+              });
+
             document.addEventListener("keydown", function handler(event) {
               if (event.key.toLowerCase() === "g") {
                 const googleCmd = config.commands["g"];
@@ -533,6 +593,16 @@
                   (isDebug ? "&debug=true" : "");
                 document.removeEventListener("keydown", handler);
                 redirectHelper(redirectUrl);
+              }
+              if (event.key.toLowerCase() === "i") {
+                addIgnoredTypo(command);
+                const googleCmd = config.commands["g"];
+                const url = googleCmd.routes[0].fallbackUrl.replace(
+                  "{args}",
+                  encodeURIComponent(query)
+                );
+                document.removeEventListener("keydown", handler);
+                redirectHelper(url);
               }
             });
             return;

--- a/index.html
+++ b/index.html
@@ -530,7 +530,7 @@
                     Search on Google <span class="shortcut-hint">(g)</span>
                   </button>
                   <button id="ignoreButton" class="error-btn">
-                    Ignore this typo <span class="shortcut-hint">(i)</span>
+                    Permanently ignore typo <span class="shortcut-hint">(i)</span>
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
Implements issue #19 by adding local storage for words that shouldn't
trigger typo detection:

- Add localStorage management functions (getIgnoredTypos, addIgnoredTypo,
  removeIgnoredTypo)
- Modify findClosestCommand to check ignore list before suggesting
- Add "Ignore this typo" button to typo detection UI
- Add keyboard shortcut 'i' to permanently ignore flagged words
- Ignored words are stored per-device using localStorage

When a user encounters a false positive typo alert, they can now press
'i' or click the ignore button to prevent future alerts for that word.