### PR TITLE
docs: add v2 successor notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> **Fast Travel App (v2) is now available.** If you want a browser extension + native Android app with one-click install and cross-device config sync, see [fast-travel-app](https://github.com/DoubleGremlin181/fast-travel-app).
+>
+> v1 (this repo) remains fully functional and is the right choice if you prefer a self-hosted static page that works in any browser without an extension.
+
 # Fast Travel
 
 **Supercharge your search bar**


### PR DESCRIPTION
Links users to fast-travel-app for the v2 extension + Android experience while making clear v1 remains the right choice for self-hosted/any-browser setups.